### PR TITLE
chore: Update Copyright format and remove 'React' constant

### DIFF
--- a/src/components/Footer/Copyright/index.tsx
+++ b/src/components/Footer/Copyright/index.tsx
@@ -1,5 +1,5 @@
 function Copyright() {
-  return <p className="text-xs flex justify-center">© 2023 boyzwhocried</p>;
+  return <p className="text-xs flex justify-center">© • 2023 • boyzwhocried</p>;
 }
 
 export default Copyright;

--- a/src/components/Footer/MadeWith/MadeWithConst.tsx
+++ b/src/components/Footer/MadeWith/MadeWithConst.tsx
@@ -1,16 +1,8 @@
-import reactLogo from "/public/assets/icon/react.svg";
 import nextjsLogo from "/public/assets/icon/next-js.svg";
 import tailwindLogo from "/public/assets/icon/tailwind.svg";
 import framermotionLogo from "/public/assets/icon/framer-motion.svg";
 
 const technologies = [
-  {
-    name: "React",
-    logoSrc: reactLogo,
-    link: "https://react.dev/",
-    scale: 1,
-    filter: "",
-  },
   {
     name: "NextJS",
     logoSrc: nextjsLogo,


### PR DESCRIPTION
1. Update the Copyright component to include separators around the year, improving the visual appearance of the copyright notice.

2. Remove the 'React' constant from the list of technologies in the MadeWithConst component, reflecting the removal of the 'React' logo from the displayed technologies.