### PR TITLE
refactor(api): Cache Spotify API data server-side

### DIFF
--- a/src/app/api/spotify/songData/index.tsx
+++ b/src/app/api/spotify/songData/index.tsx
@@ -1,23 +1,16 @@
 import GetPlaylistData from "../playlistData";
 
-interface Track {
-  name: string;
-  album: {
-    artists: { name: string }[];
-    images: { url: string }[];
-  };
-  external_urls: { spotify: string };
-}
-
-export default async function GetSongData() {
+export default async function GetSongData(currentTimestamp: number) {
   try {
     const data = await GetPlaylistData();
     const playlistData = data;
+ 
     const randomSongIndex = Math.floor(
-      Math.random() * data.tracks.items.length
+      currentTimestamp % data.tracks.items.length
     );
 
-    return playlistData.tracks.items[randomSongIndex || 0];
+    const songData = playlistData.tracks.items[randomSongIndex || 0];
+    return songData;
   } catch (error) {
     console.error("Error fetching playlist data:", error);
   }

--- a/src/components/Footer/MiniPlayer/index.tsx
+++ b/src/components/Footer/MiniPlayer/index.tsx
@@ -11,7 +11,7 @@ interface Track {
 }
 
 async function MiniPlayer() {
-  const songData = await GetSongData();
+  const songData = await GetSongData(new Date().getTime());
 
   return (
     <div>


### PR DESCRIPTION
Move data fetching logic from local storage to server-side caching by migrating hooks files to the /app/api/spotify folder.

Changes Made:
- Migrated hooks files responsible for fetching data from Spotify API.
- Data that was previously stored in the browser's local storage is now cached on the server side.

Reasoning:
- By caching the fetched data on the server side, we reduce the frequency of API calls, mitigating the risk of hitting usage limits imposed by the Spotify API.