### PR TITLE
refactor(api): Cache Spotify API data server-side

### DIFF
--- a/src/app/api/spotify/playlist-data/route.tsx
+++ b/src/app/api/spotify/playlist-data/route.tsx
@@ -1,0 +1,46 @@
+import fs from "fs/promises";
+import path from "path";
+import { GetNewPlaylistData } from "../new-playlist-data";
+import { NextResponse } from "next/server";
+
+const onRepeatPlaylistId = process.env.NEXT_PUBLIC_ON_REPEAT_PLAYLIST_ID;
+const cacheFilePath = path.resolve(".cache/cachedPlaylistData.json");
+
+export async function GET() {
+  try {
+    // Check if the cache file exists
+    const cacheFileContent = await fs.readFile(cacheFilePath, "utf-8");
+    const cachedPlaylistData = JSON.parse(cacheFileContent);
+
+    const currentTime = new Date().getTime();
+    if (cachedPlaylistData.expirationDate > currentTime) {
+      // Calculate the difference in milliseconds
+      const timeDifference = cachedPlaylistData.expirationDate - currentTime;
+      // Convert milliseconds to days
+      const daysDifference = Math.ceil(timeDifference / (1000 * 60 * 60 * 24));
+      console.log("use cached data,", `expired in ${daysDifference} days`);
+      return NextResponse.json(cachedPlaylistData.data);
+    }
+  } catch (error) {
+    // File doesn't exist or error reading file, proceed to fetch new data
+  }
+
+  console.log("use new data");
+  try {
+    const result = await GetNewPlaylistData(onRepeatPlaylistId as string);
+    const expirationDate = new Date().getTime() + 7 * 24 * 60 * 60 * 1000;
+
+    // Save the data to the cache file
+    await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+    await fs.writeFile(
+      cacheFilePath,
+      JSON.stringify({ data: result, expirationDate }),
+      "utf-8"
+    );
+
+    console.log("caching new data");
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching data:", error);
+  }
+}

--- a/src/components/Footer/MiniPlayer/index.tsx
+++ b/src/components/Footer/MiniPlayer/index.tsx
@@ -1,8 +1,13 @@
-'use client'
+"use client";
 
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
+interface PlaylistData {
+  tracks: {
+    items: { track: Track }[];
+  };
+}
 interface Track {
   name: string;
   album: {
@@ -12,44 +17,43 @@ interface Track {
   external_urls: { spotify: string };
 }
 
-interface SongDataResponse {
-  track: Track;
-}
+function MiniPlayer() {
+  const [playlistData, setPlaylistData] = useState<PlaylistData | null>(null);
+  const [randomSongIndex, setRandomSongIndex] = useState<number | null>(0);
 
- function MiniPlayer() {
-  // const response = await fetch(`/api/spotify/song-data`, { method: "GET" });
-  // const songData: SongDataResponse | undefined = await response.json();
-
-  const [songData, setSongData] = useState<SongDataResponse | undefined>(
-    undefined
-  );
-
-  const fetchSongData = async () => {
+  const fetchPlaylistData = async () => {
     try {
-      const response = await fetch("/api/spotify/song-data", { method: "GET" });
-      const songData: SongDataResponse | undefined = await response.json();
-      setSongData(songData);
+      const res = await fetch("/api/spotify/playlist-data", { method: "GET" });
+      const data = await res.json();
+      setPlaylistData(data);
+      setRandomSongIndex(Math.floor(Math.random() * data.tracks.items.length));
     } catch (error) {
-      console.error("Error fetching song data:", error);
+      console.error("Error fetching playlist data:", error);
     }
   };
 
   useEffect(() => {
-    fetchSongData();
+    fetchPlaylistData();
   }, []);
 
   return (
     <div>
-      {songData && (
+      {playlistData && (
         <a
           className="flex w-fit p-1 pr-6 gap-2 items-center bg-gradient-to-r from-primary to-accent backdrop-blur-sm shadow-xl rounded-full sm:hover:outline outline-1"
           target="_blank"
           rel="noopener noreferrer"
-          href={songData.track.external_urls.spotify}
+          href={
+            playlistData.tracks.items[randomSongIndex || 0].track.external_urls
+              .spotify
+          }
         >
           <Image
             className="rounded-full animate-spin-extra-slow h-16 w-16"
-            src={songData.track.album.images[2].url}
+            src={
+              playlistData.tracks.items[randomSongIndex || 0].track.album
+                .images[2].url
+            }
             alt="Album Cover"
             width={1000}
             height={1000}
@@ -57,8 +61,10 @@ interface SongDataResponse {
           <div>
             <h1 className="text-xs">on repeat:</h1>
             <p className="line-clamp-2 max-w-[270px]">
-              {songData.track.name} by{" "}
-              {songData.track.album.artists
+              {playlistData.tracks.items[randomSongIndex || 0].track.name} by{" "}
+              {playlistData.tracks.items[
+                randomSongIndex || 0
+              ].track.album.artists
                 .map((artist) => artist.name)
                 .join(", ")}
             </p>


### PR DESCRIPTION
Move data fetching logic from local storage to server-side caching by migrating hooks files to the /app/api/spotify folder.

Changes Made:
- Migrated hooks files responsible for fetching data from Spotify API.
- Data that was previously stored in the browser's local storage is now cached on the server side.

Reasoning:
- By caching the fetched data on the server side, we reduce the frequency of API calls, mitigating the risk of hitting usage limits imposed by the Spotify API.